### PR TITLE
extend robots.txt template for catalog-next

### DIFF
--- a/ckanext/datagovcatalog/helpers/sitemap.py
+++ b/ckanext/datagovcatalog/helpers/sitemap.py
@@ -1,0 +1,11 @@
+from urlparse import urljoin
+from ckan.lib.base import config
+
+
+def get_sitemap_url():
+    s3_url = config.get('ckanext.geodatagov.s3sitemap.aws_s3_url', 'https://filestore.data.gov/')
+    s3_path = config.get('ckanext.geodatagov.s3sitemap.aws_storage_path', 'gsa/catalog-next/sitemap')
+    
+    return urljoin(s3_url, s3_path, 'sitemap.xml')
+    
+

--- a/ckanext/datagovcatalog/plugin.py
+++ b/ckanext/datagovcatalog/plugin.py
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 class DatagovcatalogPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IActions)
+    plugins.implements(plugins.ITemplateHelpers)
 
     # IConfigurer
 
@@ -25,4 +26,11 @@ class DatagovcatalogPlugin(plugins.SingletonPlugin):
             'harvest_get_notifications_recipients': harvest_get_notifications_recipients
             }
     
-    
+    # ITemplateHelpers
+
+    def get_helpers(self):
+        from ckanext.datagovcatalog.helpers import sitemap
+
+        return {
+                'get_sitemap_url': sitemap.get_sitemap_url,
+                }

--- a/ckanext/datagovcatalog/templates/robots.txt
+++ b/ckanext/datagovcatalog/templates/robots.txt
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+{% block all_user_agents -%}
+{{ super() }}
+Disallow: /dataset?
+Disallow: /organization?
+Disallow: /harvest?
+Disallow: /group?
+Sitemap: https://filestore.data.gov/gsa/catalog/sitemap/sitemap.xml
+{%- endblock %}
+
+{% block additional_user_agents -%}
+{%- endblock %}

--- a/ckanext/datagovcatalog/templates/robots.txt
+++ b/ckanext/datagovcatalog/templates/robots.txt
@@ -6,7 +6,7 @@ Disallow: /dataset?
 Disallow: /organization?
 Disallow: /harvest?
 Disallow: /group?
-Sitemap: https://filestore.data.gov/gsa/catalog/sitemap/sitemap.xml
+Sitemap: https://filestore.data.gov/gsa/catalog-next/sitemap/sitemap.xml
 {%- endblock %}
 
 {% block additional_user_agents -%}

--- a/ckanext/datagovcatalog/templates/robots.txt
+++ b/ckanext/datagovcatalog/templates/robots.txt
@@ -6,7 +6,7 @@ Disallow: /dataset?
 Disallow: /organization?
 Disallow: /harvest?
 Disallow: /group?
-Sitemap: https://filestore.data.gov/gsa/catalog-next/sitemap/sitemap.xml
+Sitemap: {{ h.get_sitemap_url() }}
 {%- endblock %}
 
 {% block additional_user_agents -%}

--- a/ckanext/datagovcatalog/tests/test_robots_txt.py
+++ b/ckanext/datagovcatalog/tests/test_robots_txt.py
@@ -1,0 +1,42 @@
+import logging
+from urlparse import urljoin
+from nose.tools import assert_equal, assert_not_in
+from nose.plugins.skip import SkipTest
+from ckan import plugins
+
+if plugins.toolkit.check_ckan_version(min_version='2.8'):
+    from ckan.tests import helpers
+    from ckan.lib.base import config
+
+log = logging.getLogger(__name__)
+
+
+class TestRobotsTxt():
+
+    @classmethod
+    def setup_class(cls):
+        if plugins.toolkit.check_ckan_version(max_version='2.3'):
+            raise SkipTest('Robots.txt is a static file in CKAN 2.3')
+
+    def test_dynamic_robots_txt(self):
+        
+        app = helpers._get_test_app()
+        
+        url1a = 'https://test.gov/'
+        url1b = 'test/sitemap'
+        config['ckanext.geodatagov.s3sitemap.aws_s3_url'] = url1a
+        config['ckanext.geodatagov.s3sitemap.aws_storage_path'] = url1b
+        final_url = urljoin(url1a, url1b, 'sitemap.xml')
+
+        res = app.get('/robots.txt')
+        assert final_url in res
+        
+        url1a = 'https://test2.gov/'
+        url1b = 'test2/sitemap'
+        config['ckanext.geodatagov.s3sitemap.aws_s3_url'] = url1a
+        config['ckanext.geodatagov.s3sitemap.aws_storage_path'] = url1b
+        final_url = urljoin(url1a, url1b, 'sitemap.xml')
+
+        res = app.get('/robots.txt')
+        assert final_url in res
+        


### PR DESCRIPTION
Related to [multi#447](https://github.com/GSA/datagov-ckan-multi/issues/447)

This PR:
 - Extend the robots.txt template (in CKAN 2.3 is just a static file) to fit [catalog.data.gov robots.txt](https://catalog.data.gov/robots.txt) file

![image](https://user-images.githubusercontent.com/3237309/94577872-6ed32200-024d-11eb-8903-03e334add5d3.png)
