### PR TITLE
Add tracking info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,7 @@ jobs:
       - run:
           name: install
           command: bin/travis-build.bash
-      - run:
-          name: test
-          command: sh bin/travis-run.sh
-
+      
 workflows:
   version: 2
   build_and_test:

--- a/README.rst
+++ b/README.rst
@@ -51,9 +51,9 @@ Config Settings
 
 Document any optional config settings here. For example::
 
-    # The minimum number of hours to wait before re-checking a resource
-    # (optional, default: 24).
-    ckanext.datagovcatalog.some_setting = some_default_value
+    # Add tracking info on each package for the dataset lists
+    # (optional, default: true).
+    ckanext.datagovcatalog.add_packages_tracking_info = true
 
 
 ------------------------

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -1,100 +1,19 @@
 #!/bin/bash
 set -e
 
-echo "This is travis-build.bash..."
+echo "Updating script ..."
 
-echo "Installing the packages that CKAN requires..."
-sudo apt-get update -qq
-sudo apt-get install solr-jetty libcommons-fileupload-java libpq-dev postgresql postgresql-contrib python-lxml postgresql-9.3-postgis-2.1
+wget https://raw.githubusercontent.com/GSA/catalog.data.gov/master/tools/ci-scripts/circleci-build-catalog-next.bash
+wget https://raw.githubusercontent.com/GSA/catalog.data.gov/master/ckan/test-catalog-next.ini
 
-pip install --upgrade pip
-pip install setuptools -U
+sudo chmod +x circleci-build-catalog-next.bash
+source circleci-build-catalog-next.bash
 
-echo "Installing CKAN and its Python dependencies..."
-git clone https://github.com/GSA/ckan
-cd ckan
-git checkout datagov-newcatalog
-python setup.py develop
-pip install -r requirements.txt
-pip install -r dev-requirements.txt
-cd -
-
-echo "Creating the PostgreSQL user and database..."
-sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
-sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
-sudo -u postgres psql -c 'CREATE DATABASE datastore_test WITH OWNER ckan_default;'
-
-echo "Setting up PostGIS on the database..."
-sudo -u postgres psql -d ckan_test -c 'CREATE EXTENSION postgis;'
-sudo -u postgres psql -d ckan_test -c 'ALTER VIEW geometry_columns OWNER TO ckan_default;'
-sudo -u postgres psql -d ckan_test -c 'ALTER TABLE spatial_ref_sys OWNER TO ckan_default;'
-
-echo "Install other libraries required..."
-sudo apt-get install python-dev libxml2-dev libxslt1-dev libgeos-c1
-
-echo "SOLR config..."
-# Solr is multicore for tests on ckan master, but it's easier to run tests on
-# Travis single-core. See https://github.com/ckan/ckan/issues/2972
-sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
-printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
-sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
-sudo service jetty restart
-
-
-echo "-----------------------------------------------------------------"
-echo "Initialising the database..."
-cd ckan
-paster db init -c test-core.ini
-
-cd ..
-echo "-----------------------------------------------------------------"
-echo "Installing Harvester"
-git clone https://github.com/ckan/ckanext-harvest
-cd ckanext-harvest
-git checkout master
-
-python setup.py develop
-pip install -r pip-requirements.txt
-
-paster harvester initdb -c ../ckan/test-core.ini
-
-cd ..
-echo "-----------------------------------------------------------------"
-echo "Installing Spatial"
-
-git clone https://github.com/ckan/ckanext-spatial
-cd ckanext-spatial
-git checkout master
-python setup.py develop
-pip install -r pip-requirements.txt
-paster spatial initdb -c ../ckan/test-core.ini
-
-cd ..
-echo "-----------------------------------------------------------------"
-echo "Installing Geodatagov"
-git clone https://github.com/GSA/ckanext-geodatagov
-cd ckanext-geodatagov
-
-python setup.py develop
-pip install -r pip-requirements.txt
-
-cd ..
-echo "-----------------------------------------------------------------"
-echo "Installing DataGovTheme"
-git clone https://github.com/GSA/ckanext-datagovtheme
-cd ckanext-datagovtheme
-git checkout master
-
+echo "Update ckanext-datagovcatalog"
 python setup.py develop
 
-cd ..
-echo "-----------------------------------------------------------------"
-echo "Installing ckanext-datagovcatalog and its requirements..."
-python setup.py develop
+echo "Install dev.requirements"
 pip install -r dev-requirements.txt
 
-echo "Moving test.ini into a subdir..."
-mkdir subdir
-mv test.ini subdir
-
-echo "travis-build.bash is done."
+echo "TESTING ckanext-datagovtheme"
+nosetests --ckan --with-pylons=test-catalog-next.ini ckanext/datagovcatalog --debug=ckanext

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,5 +1,0 @@
-#!/bin/sh -e
-
-echo "TESTING ckanext-datagovcatalog"
-
-nosetests --ckan --with-pylons=subdir/test.ini ckanext/datagovcatalog/tests/ --nologcapture

--- a/ckanext/datagovcatalog/plugin.py
+++ b/ckanext/datagovcatalog/plugin.py
@@ -1,5 +1,5 @@
 import logging
-
+from ckan.lib.base import config
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
@@ -13,6 +13,7 @@ class DatagovcatalogPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IPackageController, inherit=True)
 
     # IConfigurer
 
@@ -34,3 +35,16 @@ class DatagovcatalogPlugin(plugins.SingletonPlugin):
         return {
                 'get_sitemap_url': sitemap.get_sitemap_url,
                 }
+    
+    ## IPackageController
+
+    def before_view(self, pkg_dict):
+        
+        if config.get('ckanext.datagovcatalog.add_packages_tracking_info', True):
+            # add tracking information.
+            # CKAN by default hide tracking info for datasets
+            pkg_dict = toolkit.get_action("package_show")({}, {
+                'include_tracking': True,
+                'id': pkg_dict['id']
+            })
+        return pkg_dict

--- a/ckanext/datagovcatalog/tests/test_collections.py
+++ b/ckanext/datagovcatalog/tests/test_collections.py
@@ -15,21 +15,7 @@ log = logging.getLogger(__name__)
 
 
 class TestCollectionSearch(object):
-
-    @classmethod
-    def setup_class(cls):
-        
-        if not p.plugin_loaded('geodatagov'):
-            p.load('geodatagov')
-        if not p.plugin_loaded('datagovcatalog'):
-            p.load('datagovcatalog')
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('datagovcatalog')
-        p.unload('geodatagov')
-        reset_db()
-        
+    
     def setup(self):
         site_user = toolkit.get_action('get_site_user')(
             {'model': model, 'ignore_auth': True}, {})['name']

--- a/ckanext/datagovcatalog/tests/test_notifications.py
+++ b/ckanext/datagovcatalog/tests/test_notifications.py
@@ -15,16 +15,10 @@ class TestExtraNotificationRecipients(object):
 
     @classmethod
     def setup_class(cls):
-        if not p.plugin_loaded('harvest'):
-            p.load('harvest')
-        if not p.plugin_loaded('datagovcatalog'):
-            p.load('datagovcatalog')
         reset_db()
 
     @classmethod
     def teardown_class(cls):
-        p.unload('datagovcatalog')
-        p.unload('harvest')
         reset_db()
 
     def test_get_extra_email_notification(self):

--- a/ckanext/datagovcatalog/tests/test_package_list.py
+++ b/ckanext/datagovcatalog/tests/test_package_list.py
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+"""Tests for tracking information."""
+
+from ckan import model
+from ckan import plugins as p
+from ckan.lib.helpers import url_for
+from ckanext.datagovcatalog.harvester.notifications import harvest_get_notifications_recipients
+from ckantoolkit.tests import factories as ckan_factories
+from ckantoolkit.tests.helpers import reset_db, FunctionalTestBase
+from nose.tools import assert_in
+
+
+class TestPackageList(FunctionalTestBase):
+
+    @classmethod
+    def setup_class(cls):
+        super(TestPackageList, cls).setup_class()
+        reset_db()
+        
+    def test_tracking_info(self):
+        
+        self._create_packages_and_tracking()
+        app = self._get_test_app()
+        res = app.get('/dataset')
+        assert_in(self.package['name'], res.unicode_body)
+        assert_in('recent views', res.unicode_body)
+
+    def _create_packages_and_tracking(self):
+
+        self.package = ckan_factories.Dataset()
+        # add 12 visit to the dataset page
+        url = url_for(controller='package', action='read',id=self.package['name'])
+        app = self._get_test_app()
+        for r in range(12):
+            self._post_to_tracking(url=url, app=app, ip='199.200.100.{}'.format(r))
+        
+    def _post_to_tracking(self, app, url, type_='page', ip='199.204.138.90',
+                          browser='firefox'):
+        '''Post some data to /_tracking directly.
+        This simulates what's supposed when you view a page with tracking
+        enabled (an ajax request posts to /_tracking).
+        '''
+
+        params = {'url': url, 'type': type_}
+        extra_environ = {
+            # The tracking middleware crashes if these aren't present.
+            'HTTP_USER_AGENT': browser,
+            'REMOTE_ADDR': ip,
+            'HTTP_ACCEPT_LANGUAGE': 'en',
+            'HTTP_ACCEPT_ENCODING': 'gzip, deflate',
+        }
+        app.post('/_tracking', params=params, extra_environ=extra_environ)

--- a/ckanext/datagovcatalog/tests/test_package_list.py
+++ b/ckanext/datagovcatalog/tests/test_package_list.py
@@ -1,10 +1,11 @@
 # encoding: utf-8
 
 """Tests for tracking information."""
-
+from datetime import datetime, timedelta
 from ckan import model
 from ckan import plugins as p
 from ckan.lib.helpers import url_for
+from ckan.lib.cli import Tracking, SearchIndexCommand
 from ckanext.datagovcatalog.harvester.notifications import harvest_get_notifications_recipients
 from ckantoolkit.tests import factories as ckan_factories
 from ckantoolkit.tests.helpers import reset_db, FunctionalTestBase
@@ -20,7 +21,12 @@ class TestPackageList(FunctionalTestBase):
         
     def test_tracking_info(self):
         
+        # Create packages and navigate them
         self._create_packages_and_tracking()
+        # update tracking info
+        self._update_tracking_info()
+        
+        # ensure we can see tracking info
         app = self._get_test_app()
         res = app.get('/dataset')
         assert_in(self.package['name'], res.unicode_body)
@@ -34,6 +40,21 @@ class TestPackageList(FunctionalTestBase):
         app = self._get_test_app()
         for r in range(12):
             self._post_to_tracking(url=url, app=app, ip='199.200.100.{}'.format(r))
+        
+    def _update_tracking_info(self):
+        # update tracking info
+        date = (datetime.now() -timedelta(days=1)).strftime('%Y-%m-%d')
+        Tracking('Tracking').update_all(engine=model.meta.engine, start_date=date)
+
+        #rebuild search index
+        class FakeOptions():
+            def __init__(self,**kwargs):
+                for key in kwargs:
+                    setattr(self,key,kwargs[key])
+        sic = SearchIndexCommand('search-index')
+        sic.args = []
+        sic.options = FakeOptions(only_missing=False, force=False, refresh=False, commit_each=False, quiet=False)
+        sic.rebuild()
         
     def _post_to_tracking(self, app, url, type_='page', ip='199.204.138.90',
                           browser='firefox'):

--- a/ckanext/datagovcatalog/tests/test_plugin.py
+++ b/ckanext/datagovcatalog/tests/test_plugin.py
@@ -8,18 +8,5 @@ import ckan.plugins
 class TestDatagovCatalogPluginLoaded(object):
     '''Tests for the ckanext.datagovcatalog.plugin module.'''
 
-    @classmethod
-    def setup_class(cls):
-        # required for the chained action
-        if not ckan.plugins.plugin_loaded('harvest'):
-            ckan.plugins.load('harvest')
-        if not ckan.plugins.plugin_loaded('datagovcatalog'):
-            ckan.plugins.load('datagovcatalog')
-    
-    @classmethod
-    def teardown_class(cls):
-        ckan.plugins.unload('datagovcatalog')
-        ckan.plugins.unload('harvest')
-
     def test_plugin_loaded(self):
         assert_true(ckan.plugins.plugin_loaded('datagovcatalog'))


### PR DESCRIPTION
Related to #10 

This PR:
 - adds tracking information for each dataset in dataset's list to allow DataGovTheme extension to show tracking data
 - Replace old script to test with the new canonical catalog-next script
 - Add test case to ensure we show tracking information in the dataset list 

![image](https://user-images.githubusercontent.com/3237309/98133311-32be5d00-1e9c-11eb-9e19-5b7cec19e445.png)
