### PR TITLE
Avoid overriding all datasets in before_view

### DIFF
--- a/ckanext/datagovcatalog/helpers/packages.py
+++ b/ckanext/datagovcatalog/helpers/packages.py
@@ -1,0 +1,11 @@
+def update_tracking_info_to_package(pkg_dict, new_pkg_dict):
+    """ override a dataset to add tracking summary information """
+
+    pkg_dict['tracking_summary'] = new_pkg_dict['tracking_summary']
+    # Add tracking information for each resource
+    for resource_dict in pkg_dict.get('resources', []):
+        for new_resource_dict in new_pkg_dict.get('resources', []):
+            if resource_dict['url'] == new_resource_dict['url']:
+                resource_dict['tracking_summary'] = new_resource_dict['tracking_summary']
+    
+    return pkg_dict

--- a/ckanext/datagovcatalog/plugin.py
+++ b/ckanext/datagovcatalog/plugin.py
@@ -45,8 +45,20 @@ class DatagovcatalogPlugin(plugins.SingletonPlugin):
             if config.get('ckanext.datagovcatalog.add_packages_tracking_info', True):
                 # add tracking information.
                 # CKAN by default hide tracking info for datasets
-                pkg_dict = toolkit.get_action("package_show")({}, {
+
+                # The pkg_dict received here could include some custom data 
+                # (like organization_type from GeoDataGov extension)
+                # just get this new data and merge witgh previous pkg_dict version
+                new_pkg_dict = toolkit.get_action("package_show")({}, {
                     'include_tracking': True,
                     'id': pkg_dict['id']
                 })
+                                
+                pkg_dict['tracking_summary'] = new_pkg_dict['tracking_summary']
+                # Add tracking information for each resource
+                for resource_dict in pkg_dict.get('resources', []):
+                    for new_resource_dict in new_pkg_dict.get('resources', []):
+                        if resource_dict['url'] == new_resource_dict['url']:
+                            resource_dict['tracking_summary'] = new_resource_dict['tracking_summary']
+
         return pkg_dict

--- a/ckanext/datagovcatalog/plugin.py
+++ b/ckanext/datagovcatalog/plugin.py
@@ -4,6 +4,7 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
 from ckanext.datagovcatalog.harvester.notifications import harvest_get_notifications_recipients
+from ckanext.datagovcatalog.helpers.packages import update_tracking_info_to_package
 
 
 log = logging.getLogger(__name__)
@@ -53,12 +54,7 @@ class DatagovcatalogPlugin(plugins.SingletonPlugin):
                     'include_tracking': True,
                     'id': pkg_dict['id']
                 })
-                                
-                pkg_dict['tracking_summary'] = new_pkg_dict['tracking_summary']
-                # Add tracking information for each resource
-                for resource_dict in pkg_dict.get('resources', []):
-                    for new_resource_dict in new_pkg_dict.get('resources', []):
-                        if resource_dict['url'] == new_resource_dict['url']:
-                            resource_dict['tracking_summary'] = new_resource_dict['tracking_summary']
+
+                pkg_dict = update_tracking_info_to_package(pkg_dict, new_pkg_dict)
 
         return pkg_dict

--- a/ckanext/datagovcatalog/tests/test_before_view.py
+++ b/ckanext/datagovcatalog/tests/test_before_view.py
@@ -1,0 +1,52 @@
+from nose.tools import assert_equal
+from ckanext.datagovcatalog.helpers.packages import update_tracking_info_to_package
+
+
+class TestOverridePackage():
+
+    def test_override_package(self):
+        
+        pkg_dict = {
+            'name': 'dataset1',
+            'organization': {
+                'name': 'org1',
+                'organization_type': 'Federal Government'
+            },
+            'resources': [
+                {'url': 'http://resources.com/resouce1.json'},
+                {'url': 'http://resources.com/resouce2.csv'},
+                {'url': 'http://resources.com/resouce3.html'}
+            ]
+        }
+
+        new_pkg_dict = {
+            'name': 'dataset1',
+            'organization': {
+                'name': 'org1'
+            },
+            'tracking_summary': 'some tracking info',
+            'resources': [
+                {'url': 'http://resources.com/resouce1.json', 'tracking_summary': 'tracking info 1'},
+                {'url': 'http://resources.com/resouce2.csv',  'tracking_summary': 'tracking info 2'},
+                {'url': 'http://resources.com/resouce3.html', 'tracking_summary': 'tracking info 3'}
+            ]
+        }
+
+        final_pkg = update_tracking_info_to_package(pkg_dict, new_pkg_dict)
+
+        assert_equal(final_pkg['tracking_summary'], 'some tracking info')
+        assert_equal(final_pkg['organization']['organization_type'], 'Federal Government')
+
+        asserts = 0
+        for resource in final_pkg['resources']:
+            if resource['url'] == 'http://resources.com/resouce1.json':
+                assert_equal(resource['tracking_summary'], 'tracking info 1')
+                asserts += 1
+            elif resource['url'] == 'http://resources.com/resouce2.csv':
+                assert_equal(resource['tracking_summary'], 'tracking info 2')
+                asserts += 1
+            elif resource['url'] == 'http://resources.com/resouce3.html':
+                assert_equal(resource['tracking_summary'], 'tracking info 3')
+                asserts += 1
+
+        assert_equal(asserts, 3)


### PR DESCRIPTION
Related to [Multi#519](https://github.com/GSA/datagov-ckan-multi/issues/519)

This PR avoid this extension to fully override datasets in the `before_view` function.