### PR TITLE
Fix README.md and future

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst
+include README.md
 include LICENSE
 include requirements.txt
 recursive-include ckanext/datagovcatalog *.html *.json *.js *.less *.css *.mo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -e git+https://github.com/GSA/ckanext-harvest.git@9d1f647d247c16b6c3acba26e321e9500cafb18c#egg=ckanext-harvest
 
 ckantoolkit==0.0.3
-future==0.18.2
 pika
 pyOpenSSL

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.0.1',
+    version='0.0.2',
 
     description='''Catalog customizations''',
     long_description=long_description,
@@ -62,6 +62,7 @@ setup(
         # ``requirements.txt`` file.
         #
         # http://docs.ckan.org/en/latest/extensions/best-practices.html#add-third-party-libraries-to-requirements-txt
+        'future',
     ],
     setup_requires=['wheel'],
 


### PR DESCRIPTION
Related to 
- https://github.com/GSA/data.gov/issues/3414
- https://github.com/GSA/catalog.data.gov/pull/493

MANIFEST.in should reference .md, not .rst; future is a real dependency, not ckan dependency