### PR TITLE
Skip tracking for api

### DIFF
--- a/ckanext/datagovcatalog/plugin.py
+++ b/ckanext/datagovcatalog/plugin.py
@@ -1,4 +1,3 @@
-import time
 import logging
 
 import ckan.plugins as plugins

--- a/ckanext/datagovcatalog/plugin.py
+++ b/ckanext/datagovcatalog/plugin.py
@@ -1,3 +1,4 @@
+import time
 import logging
 
 import ckan.plugins as plugins
@@ -10,6 +11,9 @@ from ckanext.datagovcatalog.harvester.notifications import \
     harvest_get_notifications_recipients
 from ckanext.datagovcatalog.helpers.packages import \
     update_tracking_info_to_package
+
+from ckanext.tracking.plugin import TrackingPlugin
+import types
 
 toolkit.requires_ckan_version("2.9")
 
@@ -26,6 +30,28 @@ class DatagovcatalogPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     # IConfigurer
     def update_config(self, config):
         plugins.toolkit.add_public_directory(config, "../public")
+
+        """
+        Monkey-patch TrackingPlugin.after_dataset_search to improve API performance.
+        Skips tracking summary lookups during /api/3/action/package_search requests,
+        which speeds up responses when handling large CKAN datasets.
+        """
+        def safe_after_dataset_search(self, search_results, search_params):
+            request = toolkit.request
+            if request.path.startswith('/api'):
+                log.info("Skipping tracking plugin for API call")
+                return search_results
+
+            # Call the original method if not API
+            return safe_after_dataset_search.original(self, search_results, search_params)
+
+        # Backup original method
+        safe_after_dataset_search.original = TrackingPlugin.after_dataset_search
+
+        # Apply patch
+        TrackingPlugin.after_dataset_search = types.MethodType(
+            safe_after_dataset_search, TrackingPlugin
+        )
 
     # ITemplateHelpers
     def get_helpers(self):


### PR DESCRIPTION
Related issue: https://github.com/GSA/data.gov/issues/5174

Monkey-patch TrackingPlugin.after_dataset_search to skip tracking summary for API calls. 
This improves performance for /api/3/action/package_search with large datasets.