### PR TITLE
Fix tracking issue

### DIFF
--- a/ckanext/datagovcatalog/plugin.py
+++ b/ckanext/datagovcatalog/plugin.py
@@ -37,7 +37,7 @@ class DatagovcatalogPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         """
         def safe_after_dataset_search(self, search_results, search_params):
             request = toolkit.request
-            if request.path.startswith('/api'):
+            if request and request.path.startswith('/api'):
                 log.info("Skipping tracking plugin for API call")
                 return search_results
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.1.2',
+    version='0.1.3',
 
     description='''Catalog customizations''',
     long_description=long_description,


### PR DESCRIPTION
Add a request existence check before accessing request.path to prevent errors when no active HTTP request is available.